### PR TITLE
feat: call DISPATCH directly & auto complete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 coverage
 *.log*
 dist
+.vscode

--- a/README.md
+++ b/README.md
@@ -302,6 +302,102 @@ function sleep(ms) {
 
 see [async-bin](test/fixtures/async-bin) for more detail.
 
+
+### Bash-Completions
+
+```bash
+# exec below will print usage for auto bash completion
+$ my-git completion
+# exec below will mount auto completion to your bash
+$ my-git completion >> ~/.bashrc
+```
+
+![Bash-Completions](https://cloud.githubusercontent.com/assets/227713/23980327/0a00e1a0-0a3a-11e7-81be-23b4d54d91ad.gif)
+
+
+## Migrating from v1 to v2
+
+### bin
+
+- `run` method is not longer exist.
+
+```js
+// 1.x
+const run = require('common-bin').run;
+run(require('../lib/my_program'));
+
+// 2.x
+// require a main Command
+const Command = require('..');
+new Command().start();
+```
+
+### Program
+
+- `Program` is just a `Command` sub class, you can call it `Main Command` now.
+- `addCommand()` is replace with `add()`.
+- Recommand to use `load()` to load the whole command directory.
+
+```js
+// 1.x
+this.addCommand('test', path.join(__dirname, 'test_command.js'));
+
+// 2.x
+const Command = require('common-bin');
+const pkg = require('./package.json');
+class MainCommand extends Command {
+  constructor() {
+    super();
+
+    this.add('test', path.join(__dirname, 'test_command.js'));
+    // or load the entire directory
+    this.load(path.join(__dirname, 'command'));
+  });
+```
+
+### Command
+
+- `help()` is not use anymore.
+- should provide `name`, `description`, `options`.
+- `* run()` arguments had change to object, recommand to use destructuring style - `{ cwd, argv, rawArgv }`
+  - `argv` is an object parse by `yargs`, **not `args`.**
+  - `rawArgv` is equivalent to old `args`
+
+```js
+// 1.x
+class TestCommand extends Command {
+  * run(cwd, args) {
+    console.log('run mocha test at %s with %j', cwd, args);
+  }
+}
+
+// 2.x
+class TestCommand extends Command {
+  constructor() {
+    super();
+    // my-bin test --require=co-mocha
+    this.options = {
+      require: {
+        description: 'require module name',
+      },
+    };
+  }
+
+  * run({ cwd, argv, rawArgv }) {
+    console.log('run mocha test at %s with %j', cwd, argv);
+  }
+
+  get description() {
+    return 'unit test';
+  }
+}
+```
+
+### helper
+
+- `getIronNodeBin` is remove.
+- `child.kill` now support signal.
+
 ## License
 
 [MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -306,9 +306,9 @@ see [async-bin](test/fixtures/async-bin) for more detail.
 ### Bash-Completions
 
 ```bash
-# exec below will print usage for auto bash completion
+$ # exec below will print usage for auto bash completion
 $ my-git completion
-# exec below will mount auto completion to your bash
+$ # exec below will mount auto completion to your bash
 $ my-git completion >> ~/.bashrc
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ npm i common-bin --save-dev
 
 You maybe need a custom xxx-bin to implement more custom features.
 
-Now you can implement a [Program](lib/program.js) sub class, and [Command](lib/command.js) sub class to do that.
+Now you can implement a [Command](lib/command.js) sub class to do that.
 
 ### Example: Write your own `git` command
 
@@ -79,7 +79,7 @@ const pkg = require('./package.json';
 class MainCommand extends Command {
   constructor(argv) {
     super(argv);
-    this.yargs.usage('Usage: my-git <command> [options]');
+    this.usage = 'Usage: my-git <command> [options]';
 
     // load entire command directory
     this.load(path.join(__dirname, 'command'));
@@ -103,7 +103,7 @@ class CloneCommand extends Command {
   constructor(argv) {
     super(argv);
 
-    this.yargs.options({
+    this.options = {
       depth: {
         type: 'number',
         description: 'Create a shallow clone with a history truncated to the specified number of commits',
@@ -151,6 +151,8 @@ Define the main logic of command
 - `add(name, filePath)` - register special file to command with command name
 - `alias(alias, name)` - register a command with an existing command
 - `showHelp()` - print usage message to console.
+- `options=` - a setter, shortcut for `yargs.options`
+- `usage=` - a setter, shortcut for `yargs.usage`
 
 **Properties:**
 
@@ -185,7 +187,7 @@ this.yargs.options({
 - `forkNode(modulePath, args, opt)`
 - `npmInstall(npmCli, name, cwd)`
 
-**Extend:**
+**Extend Helper**
 
 ```js
 // index.js

--- a/lib/command.js
+++ b/lib/command.js
@@ -98,6 +98,12 @@ class CommonBin {
    */
   start() {
     co(function* () {
+      // replace `--get-yargs-completions` to our KEY, so yargs will not block our DISPATCH
+      const index = this.rawArgv.indexOf('--get-yargs-completions');
+      if (index !== -1) {
+        this.rawArgv.splice(this.rawArgv.indexOf('--get-yargs-completions'), 2);
+        this.rawArgv.unshift(`--AUTO_COMPLETIONS=${this.rawArgv.join(',')}`);
+      }
       yield this[DISPATCH]();
     }.bind(this)).catch(this.errorHandler.bind(this));
   }
@@ -194,10 +200,9 @@ class CommonBin {
 
     // print completion
     if (context.argv.AUTO_COMPLETIONS) {
-      const completionArgv = context.argv._.length ? context.argv._ : context.argv.AUTO_COMPLETIONS.split('');
-      this.yargs.getCompletion(completionArgv, completions => {
+      this.yargs.getCompletion(this.rawArgv.slice(1), completions => {
         // console.log('%s', completions)
-        completions.forEach(x => console.log(x));
+        completions.filter(x => x !== 'completion').forEach(x => console.log(x));
       });
     } else {
        // handle by self
@@ -207,13 +212,6 @@ class CommonBin {
 
   [PARSE](argv) {
     return new Promise((resolve, reject) => {
-      // replace `--get-yargs-completions` to our KEY, so yargs will not block our DISPATCH
-      const index = this.rawArgv.indexOf('--get-yargs-completions');
-      if (index !== -1) {
-        // when `my-git remote add --<TAB>` should add `-` to get options completion
-        const v = this.rawArgv[this.rawArgv.length - 1][0] === '-' ? '-' : '""';
-        this.rawArgv.splice(this.rawArgv.indexOf('--get-yargs-completions'), 2, `--AUTO_COMPLETIONS=${v}`);
-      }
       this.yargs.parse(argv, (err, argv) => {
         if (err) return reject(err);
         resolve(argv);

--- a/lib/command.js
+++ b/lib/command.js
@@ -101,8 +101,7 @@ class CommonBin {
       // replace `--get-yargs-completions` to our KEY, so yargs will not block our DISPATCH
       const index = this.rawArgv.indexOf('--get-yargs-completions');
       if (index !== -1) {
-        this.rawArgv.splice(this.rawArgv.indexOf('--get-yargs-completions'), 2);
-        this.rawArgv.unshift(`--AUTO_COMPLETIONS=${this.rawArgv.join(',')}`);
+        this.rawArgv.splice(this.rawArgv.indexOf('--get-yargs-completions'), 2, `--AUTO_COMPLETIONS=${this.rawArgv.join(',')}`);
       }
       yield this[DISPATCH]();
     }.bind(this)).catch(this.errorHandler.bind(this));
@@ -199,7 +198,7 @@ class CommonBin {
     };
 
     // print completion for bash
-    if (context.argv.AUTO_COMPLETIONS) {
+    if (context.argv.hasOwnProperty('AUTO_COMPLETIONS')) {
       this.yargs.getCompletion(this.rawArgv.slice(1), completions => {
         // console.log('%s', completions)
         completions.forEach(x => console.log(x));

--- a/lib/command.js
+++ b/lib/command.js
@@ -198,11 +198,11 @@ class CommonBin {
       rawArgv: this.rawArgv,
     };
 
-    // print completion
+    // print completion for bash
     if (context.argv.AUTO_COMPLETIONS) {
       this.yargs.getCompletion(this.rawArgv.slice(1), completions => {
         // console.log('%s', completions)
-        completions.filter(x => x !== 'completion').forEach(x => console.log(x));
+        completions.forEach(x => console.log(x));
       });
     } else {
        // handle by self

--- a/lib/command.js
+++ b/lib/command.js
@@ -154,15 +154,6 @@ class CommonBin {
    * @private
    */
   * [DISPATCH]() {
-    // define --help and --version by default
-    this.yargs
-      // .completion()
-      .wrap(120)
-      .version()
-      .help()
-      .alias('h', 'help')
-      .group([ 'help', 'version' ], 'Global Options:');
-
     // get parsed argument without handling helper and version
     const parsed = yield this[PARSE](this.rawArgv);
     const commandName = parsed._[0];
@@ -170,14 +161,24 @@ class CommonBin {
     // if sub command exist
     if (this[COMMANDS].has(commandName)) {
       const Command = this[COMMANDS].get(commandName);
-      debug('[%s] dispatch to subcommand `%s` -> `%s`', this.constructor.name, commandName, Command.name);
-
       const rawArgv = this.rawArgv.slice();
       rawArgv.splice(rawArgv.indexOf(commandName), 1);
+
+      debug('[%s] dispatch to subcommand `%s` -> `%s` with %j', this.constructor.name, commandName, Command.name, rawArgv);
       const command = new Command(rawArgv);
-      yield this.helper.callFn(command[DISPATCH], [], command);
+      yield command[DISPATCH]();
       return;
     }
+
+    // define --help and --version by default
+    this.yargs
+      // .reset()
+      .completion()
+      .help()
+      .wrap(120)
+      .version()
+      .alias('h', 'help')
+      .group([ 'help', 'version' ], 'Global Options:');
 
     // register command for printing
     for (const [ name, Command ] of this[COMMANDS].entries()) {
@@ -190,12 +191,29 @@ class CommonBin {
       cwd: process.cwd(),
       rawArgv: this.rawArgv,
     };
-    // handle by self
-    yield this.helper.callFn(this.run, [ context ], this);
+
+    // print completion
+    if (context.argv.AUTO_COMPLETIONS) {
+      const completionArgv = context.argv._.length ? context.argv._ : context.argv.AUTO_COMPLETIONS.split('');
+      this.yargs.getCompletion(completionArgv, completions => {
+        // console.log('%s', completions)
+        completions.forEach(x => console.log(x));
+      });
+    } else {
+       // handle by self
+      yield this.helper.callFn(this.run, [ context ], this);
+    }
   }
 
   [PARSE](argv) {
     return new Promise((resolve, reject) => {
+      // replace `--get-yargs-completions` to our KEY, so yargs will not block our DISPATCH
+      const index = this.rawArgv.indexOf('--get-yargs-completions');
+      if (index !== -1) {
+        // when `my-git remote add --<TAB>` should add `-` to get options completion
+        const v = this.rawArgv[this.rawArgv.length - 1][0] === '-' ? '-' : '""';
+        this.rawArgv.splice(this.rawArgv.indexOf('--get-yargs-completions'), 2, `--AUTO_COMPLETIONS=${v}`);
+      }
       this.yargs.parse(argv, (err, argv) => {
         if (err) return reject(err);
         resolve(argv);

--- a/lib/command.js
+++ b/lib/command.js
@@ -101,6 +101,7 @@ class CommonBin {
       // replace `--get-yargs-completions` to our KEY, so yargs will not block our DISPATCH
       const index = this.rawArgv.indexOf('--get-yargs-completions');
       if (index !== -1) {
+        // bash will request as `--get-yargs-completions my-git remote add`, so need to remove 2
         this.rawArgv.splice(this.rawArgv.indexOf('--get-yargs-completions'), 2, `--AUTO_COMPLETIONS=${this.rawArgv.join(',')}`);
       }
       yield this[DISPATCH]();
@@ -198,7 +199,8 @@ class CommonBin {
     };
 
     // print completion for bash
-    if (context.argv.hasOwnProperty('AUTO_COMPLETIONS')) {
+    if (context.argv.AUTO_COMPLETIONS) {
+      // slice to remove `--AUTO_COMPLETIONS=` which we append
       this.yargs.getCompletion(this.rawArgv.slice(1), completions => {
         // console.log('%s', completions)
         completions.forEach(x => console.log(x));

--- a/lib/command.js
+++ b/lib/command.js
@@ -160,6 +160,16 @@ class CommonBin {
    * @private
    */
   * [DISPATCH]() {
+    // define --help and --version by default
+    this.yargs
+      // .reset()
+      .completion()
+      .help()
+      .wrap(120)
+      .version()
+      .alias('h', 'help')
+      .group([ 'help', 'version' ], 'Global Options:');
+
     // get parsed argument without handling helper and version
     const parsed = yield this[PARSE](this.rawArgv);
     const commandName = parsed._[0];
@@ -175,16 +185,6 @@ class CommonBin {
       yield command[DISPATCH]();
       return;
     }
-
-    // define --help and --version by default
-    this.yargs
-      // .reset()
-      .completion()
-      .help()
-      .wrap(120)
-      .version()
-      .alias('h', 'help')
-      .group([ 'help', 'version' ], 'Global Options:');
 
     // register command for printing
     for (const [ name, Command ] of this[COMMANDS].entries()) {

--- a/test/fixtures/my-bin/command/start.js
+++ b/test/fixtures/my-bin/command/start.js
@@ -15,8 +15,9 @@ class StartCommand extends Command {
     });
   }
 
-  * run({ cwd, argv }) {
+  * run({ cwd, argv, rawArgv }) {
     console.log('run start command at %s with port %j', cwd, argv.port);
+    console.log('rawArgv: %s', rawArgv);
     yield this.helper.forkNode(path.join(__dirname, 'start-cluster'), [ '--port', argv.port ]);
   }
 

--- a/test/fixtures/my-git/bin/my-git.js
+++ b/test/fixtures/my-git/bin/my-git.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node #--debug-brk --inspect
+#!/usr/bin/env node --debug-brk --inspect
 
 'use strict';
 

--- a/test/fixtures/my-git/bin/my-git.js
+++ b/test/fixtures/my-git/bin/my-git.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node #--debug-brk --inspect
 
 'use strict';
 

--- a/test/fixtures/my-git/bin/my-git.js
+++ b/test/fixtures/my-git/bin/my-git.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --debug-brk --inspect
+#!/usr/bin/env node #--debug-brk --inspect
 
 'use strict';
 

--- a/test/my-git.test.js
+++ b/test/my-git.test.js
@@ -56,7 +56,7 @@ describe('test/my-git.test.js', () => {
     // https://github.com/yargs/yargs/issues/570
     it.skip('my-git clone <repository>', done => {
       coffee.fork(myBin, [ 'clone', repository, 'common-bin', '--depth=1' ], { cwd })
-        .debug()
+        // .debug()
         // .coverage(false)
         .expect('stdout', /git clone .*node-modules\/common-bin to common-bin with depth 1/)
         .expect('code', 0)
@@ -145,5 +145,53 @@ describe('test/my-git.test.js', () => {
         .expect('code', 0)
         .end(done);
     });
+  });
+
+  describe('bash-completion', () => {
+    it('--get-yargs-completions my-git', done => {
+      coffee.fork(myBin, [ '--get-yargs-completions', 'my-git' ], { cwd })
+        // .debug()
+        // .coverage(false)
+        .expect('stdout', /completion/)
+        .expect('stdout', /clone/)
+        .expect('stdout', /remote/)
+        .notExpect('stdout', /Usage:/)
+        .expect('code', 0)
+        .end(done);
+    });
+
+    it('--get-yargs-completions my-git remote', done => {
+      coffee.fork(myBin, [ '--get-yargs-completions', 'my-git', 'remote' ], { cwd })
+        // .debug()
+        // .coverage(false)
+        .expect('stdout', /completion/)
+        .expect('stdout', /add/)
+        .expect('stdout', /remove/)
+        .expect('stdout', /rm/)
+        .notExpect('stdout', /Usage:/)
+        .expect('code', 0)
+        .end(done);
+    });
+
+    it('--get-yargs-completions my-git remote add', done => {
+      coffee.fork(myBin, [ '--get-yargs-completions', 'my-git', 'remote', 'add', '-' ], { cwd })
+        // .debug()
+        // .coverage(false)
+        .expect('stdout', /--tags/)
+        .notExpect('stdout', /Usage:/)
+        .expect('code', 0)
+        .end(done);
+    });
+
+    it('--get-yargs-completions my-git remote add', done => {
+      coffee.fork(myBin, [ '--get-yargs-completions', 'my-git', 'remote', 'add', '--' ], { cwd })
+        // .debug()
+        // .coverage(false)
+        .expect('stdout', /--tags/)
+        .notExpect('stdout', /Usage:/)
+        .expect('code', 0)
+        .end(done);
+    });
+
   });
 });

--- a/test/my-git.test.js
+++ b/test/my-git.test.js
@@ -33,6 +33,17 @@ describe('test/my-git.test.js', () => {
         .end(done);
     });
 
+    it('my-git -h remote', done => {
+      coffee.fork(myBin, [ '-h', 'remote' ], { cwd })
+        // .debug()
+        .expect('stdout', /Usage: my-git remote/)
+        .expect('stdout', /Commands:/)
+        .expect('stdout', /add\s*Adds a remote/)
+        .expect('stdout', /remove\s*Remove the remote/)
+        .expect('code', 0)
+        .end(done);
+    });
+
     it('my-git', done => {
       coffee.fork(myBin, [], { cwd })
         // .debug()


### PR DESCRIPTION
更新内容：
- `DISPATCH` 直接调用即可
- `yargs` 逻辑后置到调用 `run` 之前
- 加上遗漏的 Migrating 文档
- 增加 bash-completions 自动补全功能

~~昨晚研究了下 bash-completion，现在我们这种方式，很难做到，要 hack 很多... 我写完了，但代码看起来好恶心。。。要不然需要自己参考它的那段处理自己输出 completion，要不然就得用之前的方案才行。~~

优化了下逻辑，虽然还是 hack，但看起来稍微好一点了。。。


![untitled](https://cloud.githubusercontent.com/assets/227713/23980327/0a00e1a0-0a3a-11e7-81be-23b4d54d91ad.gif)
