### PR TITLE
feat: support parserOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ Define the main logic of command
 - `description` - {String} a getter, only show this description when it's a sub command in help console
 - `helper` - {Object} helper instance
 - `yargs` - {Object} yargs instance for advanced custom usage
+- `parserOptions` - {Object} control `context` parse rule.
+  - `execArgv` - {Boolean} whether extract `execArgv` to `context.execArgv`
+  - `removeAlias` - {Boolean} whether remove alias key from `argv`
+  - `removeCamelCase` - {Boolean} whether remove camel case key from `argv`
 
 You can define options using yargs
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -7,6 +7,7 @@ const helper = require('./helper');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
+const changeCase = require('change-case');
 const DISPATCH = Symbol('Command#dispatch');
 const PARSE = Symbol('Command#parse');
 const COMMANDS = Symbol('Command#commands');
@@ -26,6 +27,19 @@ class CommonBin {
      * @type {Object}
      */
     this.yargs = yargs(this.rawArgv);
+
+    /**
+     * parserOptions
+     * @type {Object}
+     * @property {Boolean} execArgv - whether extract `execArgv` to `context.execArgv`
+     * @property {Boolean} removeAlias - whether remove alias key from `argv`
+     * @property {Boolean} removeCamelCase - whether remove camel case key from `argv`
+     */
+    this.parserOptions = {
+      execArgv: false,
+      removeAlias: false,
+      removeCamelCase: false,
+    };
 
     // <commandName, Command>
     this[COMMANDS] = new Map();
@@ -215,15 +229,68 @@ class CommonBin {
    */
   get context() {
     const argv = this.yargs.argv;
-    argv.help = undefined;
-    argv.h = undefined;
-    argv.version = undefined;
-
-    return {
+    const context = {
       argv,
       cwd: process.cwd(),
       rawArgv: this.rawArgv,
     };
+
+    argv.help = undefined;
+    argv.h = undefined;
+    argv.version = undefined;
+
+    // remove alias result
+    if (this.parserOptions.removeAlias) {
+      const aliases = this.yargs.getOptions().alias;
+      for (const key of Object.keys(aliases)) {
+        aliases[key].forEach(item => {
+          argv[item] = undefined;
+        });
+      }
+    }
+
+    // remove camel case result
+    if (this.parserOptions.removeCamelCase) {
+      for (const key of Object.keys(argv)) {
+        if (key.includes('-')) {
+          argv[changeCase.camel(key)] = undefined;
+        }
+      }
+    }
+
+    // extract execArgv
+    if (this.parserOptions.execArgv) {
+      const execArgvObj = {};
+      for (const key of Object.keys(argv)) {
+        const value = argv[key];
+
+        if (value === undefined) continue;
+
+        // debug / debug-brk / debug-port / inspect / inspect-brk / inspect-port
+        if (match(key, [ /^debug.*/, /^inspect.*/ ])) {
+          // extract debug port
+          if (typeof value === 'number') context.debugPort = value;
+          execArgvObj[key] = value;
+          argv[key] = undefined;
+          continue;
+        }
+
+        // others execArgv
+        if (match(key, [ 'es_staging', 'expose_debug_as', /^harmony.*/ ])) {
+          execArgvObj[key] = value;
+          argv[key] = undefined;
+          continue;
+        }
+      }
+
+      // only exports execArgv when any match
+      if (Object.keys(execArgvObj).length) {
+        context.execArgvObj = execArgvObj;
+        context.execArgv = this.helper.unparseArgv(execArgvObj);
+      }
+    }
+
+    return context;
   }
 
   [PARSE](rawArgv) {
@@ -235,6 +302,12 @@ class CommonBin {
       });
     });
   }
+}
+
+function match(key, arr) {
+  return arr.some(x => {
+    return x instanceof RegExp ? x.test(key) : x === key;
+  });
 }
 
 module.exports = CommonBin;

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -144,7 +144,7 @@ exports.callFn = function* (fn, args = [], thisArg) {
  * @param {Array} [options.excludes] - keys or regex of keys to exclude
  * @return {Array} [ '--debug=7000', '--debug-brk' ]
  */
-exports.unparseArgv = function(argv, options = {}) {
+exports.unparseArgv = (argv, options = {}) => {
   // revert argv object to array
   // yargs will paser `debug-brk` to `debug-brk` and `debugBrk`, so we need to filter
   return [ ...new Set(unparse(argv, options)) ];

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Abstraction bin tool",
   "main": "index.js",
   "dependencies": {
+    "change-case": "^3.0.1",
     "co": "^4.6.0",
     "dargs": "^5.1.0",
     "debug": "^2.6.3",
@@ -11,14 +12,15 @@
     "yargs": "^7.0.2"
   },
   "devDependencies": {
-    "autod": "^2.7.1",
+    "autod": "^2.8.0",
     "coffee": "^3.3.0",
-    "egg-bin": "^2.4.0",
+    "egg-bin": "^3.2.1",
     "egg-ci": "^1.5.0",
-    "eslint": "^3.17.1",
+    "eslint": "^3.19.0",
     "eslint-config-egg": "^3.2.0",
     "mm": "^2.1.0",
-    "rimraf": "^2.6.1"
+    "rimraf": "^2.6.1",
+    "webstorm-disable-index": "^1.1.2"
   },
   "repository": {
     "type": "git",

--- a/test/fixtures/my-bin/command/parserOptions.js
+++ b/test/fixtures/my-bin/command/parserOptions.js
@@ -5,6 +5,12 @@ const Command = require('../../../..');
 class ContextCommand extends Command {
   constructor(rawArgv) {
     super(rawArgv);
+    this.parserOptions = {
+      execArgv: true,
+      removeAlias: true,
+      removeCamelCase: true,
+    };
+
     this.options = {
       baseDir: {
         description: 'target directory',
@@ -14,9 +20,10 @@ class ContextCommand extends Command {
   }
 
 
-  * run({ argv, execArgv }) {
+  * run({ argv, execArgv, debugPort }) {
     console.log('argv: %j', argv);
     console.log('execArgv: %s', execArgv);
+    console.log('debugPort: %s', debugPort);
   }
 
   get description() {

--- a/test/fixtures/my-git/bin/my-git.js
+++ b/test/fixtures/my-git/bin/my-git.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --debug-brk --inspect
+#!/usr/bin/env node #--debug-brk --inspect
 
 'use strict';
 

--- a/test/my-bin.test.js
+++ b/test/my-bin.test.js
@@ -94,11 +94,45 @@ describe('test/my-bin.test.js', () => {
         .end(done);
     });
 
-    it('my-bin context', done => {
-      coffee.fork(myBin, [ 'context' ], { cwd })
+    it('my-bin parserOptions', done => {
+      const args = [
+        'parserOptions',
+        '--baseDir=./dist',
+        '--debug', '--debug-brk=5555',
+        '--expose_debug_as=v8debug',
+        '--inspect', '6666', '--inspect-brk',
+        '--es_staging', '--harmony', '--harmony_default_parameters',
+      ];
+      coffee.fork(myBin, args, { cwd })
         // .debug()
         // .coverage(false)
-        .expect('stdout', /execArgv: --inspect/)
+        .notExpect('stdout', /"b":".\/dist"/)
+        .expect('stdout', /"baseDir":".\/dist"/)
+        .notExpect('stdout', /"debug-brk":5555,/)
+        .notExpect('stdout', /"debugBrk":5555,/)
+        .expect('stdout', /execArgv: --debug,--debug-brk=5555,--expose_debug_as=v8debug,--inspect=6666,--inspect-brk,--es_staging,--harmony,--harmony_default_parameters/)
+        .expect('stdout', /debugPort: 6666/)
+        .expect('code', 0)
+        .end(done);
+    });
+
+    it('my-bin context', done => {
+      const args = [
+        'context',
+        '--baseDir=./dist',
+        '--debug', '--debug-brk=5555',
+        '--expose_debug_as=v8debug',
+        '--inspect', '6666', '--inspect-brk',
+        '--es_staging', '--harmony', '--harmony_default_parameters',
+      ];
+      coffee.fork(myBin, args, { cwd })
+        // .debug()
+        // .coverage(false)
+        .expect('stdout', /"b":".\/dist"/)
+        .expect('stdout', /"baseDir":".\/dist"/)
+        .expect('stdout', /"debug-brk":5555,/)
+        .expect('stdout', /"debugBrk":5555,/)
+        .expect('stdout', /execArgv: undefined/)
         .expect('code', 0)
         .end(done);
     });


### PR DESCRIPTION
- `parserOptions` - {Object} control `context` parse rule.
  - `execArgv` - {Boolean} whether extract `execArgv` to `context.execArgv`
  - `removeAlias` - {Boolean} whether remove alias key from `argv`
  - `removeCamelCase` - {Boolean} whether remove camel case key from `argv`