### PR TITLE
feat: extract execArgv from node-options && add unparseExecArgv

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -309,9 +309,17 @@ class CommonBin {
         argv[changeCase.camel(key)] = undefined;
       }
 
+      // extract from `--node_options`, should behide `remove` code
+      if (argv.node_options) {
+        const argvFromOptions = parser(argv.node_options);
+        Object.assign(execArgvObj, argvFromOptions);
+        argv.node_options = undefined;
+        argv.nodeOptions = undefined;
+      }
+
       // only exports execArgv when any match
       if (Object.keys(execArgvObj).length) {
-        context.execArgv = this.helper.unparseArgv(execArgvObj);
+        context.execArgv = this.helper.unparseExecArgv(execArgvObj);
         context.execArgvObj = execArgvObj;
         context.debugOptions = debugOptions;
         context.debugPort = debugPort;

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -151,6 +151,27 @@ exports.unparseArgv = (argv, options = {}) => {
 };
 
 /**
+ * unparse argv and change it to execArgv array style
+ * like `unparseArgv` but will process special key like `-r`, it should be `-r test.js` not `-r=test.js`.
+ * @method helper#unparseExecArgv
+ * @param {Object} argv - yargs style
+ * @return {Array} [ '--debug=7000', '--debug-brk', '-r' 'test.js' ]
+ */
+exports.unparseExecArgv = argv => {
+  const set = new Set(unparse(argv));
+  const execArgv = [];
+  set.forEach(item => {
+    if (item.startsWith('--r=') || item.startsWith('--require=')) {
+      execArgv.push('-r');
+      execArgv.push(item.split('=')[1]);
+    } else {
+      execArgv.push(item);
+    }
+  });
+  return execArgv;
+};
+
+/**
  * extract execArgv from argv
  * @method helper#extractExecArgv
  * @param {Object} argv - yargs style

--- a/test/fixtures/my-bin/command/nodeOptions.js
+++ b/test/fixtures/my-bin/command/nodeOptions.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const Command = require('../../../..');
+const path = require('path');
+
+class NodeOptionsCommand extends Command {
+  constructor(rawArgv) {
+    super(rawArgv);
+    this.parserOptions = {
+      execArgv: true,
+    };
+  }
+
+
+  * run({ execArgv }) {
+    console.log('execArgv: %s', execArgv);
+    yield this.helper.forkNode(path.join(__dirname, 'start-cluster'), [], { execArgv });
+  }
+
+  get description() {
+    return 'node options';
+  }
+}
+
+module.exports = NodeOptionsCommand;

--- a/test/fixtures/my-bin/command/parserDebug.js
+++ b/test/fixtures/my-bin/command/parserDebug.js
@@ -2,7 +2,7 @@
 
 const Command = require('../../../..');
 
-class ContextCommand extends Command {
+class ParserDebugCommand extends Command {
   constructor(rawArgv) {
     super(rawArgv);
     this.parserOptions = {
@@ -27,8 +27,8 @@ class ContextCommand extends Command {
   }
 
   get description() {
-    return 'custom context';
+    return 'parser debug';
   }
 }
 
-module.exports = ContextCommand;
+module.exports = ParserDebugCommand;

--- a/test/fixtures/my-bin/command/parserOptions.js
+++ b/test/fixtures/my-bin/command/parserOptions.js
@@ -2,7 +2,7 @@
 
 const Command = require('../../../..');
 
-class ContextCommand extends Command {
+class ParserOptionsCommand extends Command {
   constructor(rawArgv) {
     super(rawArgv);
     this.parserOptions = {
@@ -27,8 +27,8 @@ class ContextCommand extends Command {
   }
 
   get description() {
-    return 'custom context';
+    return 'parser options';
   }
 }
 
-module.exports = ContextCommand;
+module.exports = ParserOptionsCommand;

--- a/test/fixtures/my-bin/r.js
+++ b/test/fixtures/my-bin/r.js
@@ -1,0 +1,3 @@
+'use strict';
+
+console.log('should be require by --node_options 1');

--- a/test/fixtures/my-bin/r2.js
+++ b/test/fixtures/my-bin/r2.js
@@ -1,0 +1,3 @@
+'use strict';
+
+console.log('should be require by --node_options 2');

--- a/test/fixtures/my-bin/r3.js
+++ b/test/fixtures/my-bin/r3.js
@@ -1,0 +1,3 @@
+'use strict';
+
+console.log('should be require by --node_options 3');

--- a/test/my-bin.test.js
+++ b/test/my-bin.test.js
@@ -217,23 +217,40 @@ describe('test/my-bin.test.js', () => {
         .end(done);
     });
 
+    it('my-bin nodeOptions', done => {
+      const r = path.join(__dirname, './fixtures/my-bin/r.js');
+      const r2 = path.join(__dirname, './fixtures/my-bin/r2.js');
+      const r3 = path.join(__dirname, './fixtures/my-bin/r3.js');
+      const args = [
+        'nodeOptions',
+        `--node_options=-r ${r} -r=${r2} --require ${r3} --no-deprecation`,
+      ];
+      coffee.fork(myBin, args, { cwd })
+        // .debug()
+        .expect('stdout', /should be require by --node_options 1/)
+        .expect('stdout', /should be require by --node_options 2/)
+        .expect('stdout', /should be require by --node_options 3/)
+        .expect('stdout', /execArgv: .*--no-deprecation/)
+        .expect('code', 0)
+        .end(done);
+    });
+
     it('my-bin parserOptions', done => {
       const args = [
         'parserOptions',
-        '--baseDir=./dist',
-        '--debug', '--debug-brk=5555',
-        '--expose_debug_as=v8debug',
-        '--inspect', '6666', '--inspect-brk',
-        '--es_staging', '--harmony', '--harmony_default_parameters',
+        '-b=./dist',
+        '--test-me',
+        '--debug=6666',
       ];
       coffee.fork(myBin, args, { cwd })
         // .debug()
         // .coverage(false)
         .notExpect('stdout', /"b":".\/dist"/)
         .expect('stdout', /"baseDir":".\/dist"/)
-        .notExpect('stdout', /"debug-brk":5555,/)
-        .notExpect('stdout', /"debugBrk":5555,/)
-        .expect('stdout', /execArgv: --debug,--debug-brk=5555,--expose_debug_as=v8debug,--inspect=6666,--inspect-brk,--es_staging,--harmony,--harmony_default_parameters/)
+        .expect('stdout', /"test-me":true,/)
+        .notExpect('stdout', /"testMe":true,/)
+        .notExpect('stdout', /"debug":6666,/)
+        .expect('stdout', /execArgv: --debug=6666/)
         .expect('stdout', /debugPort: 6666/)
         .expect('code', 0)
         .end(done);

--- a/test/my-helper.test.js
+++ b/test/my-helper.test.js
@@ -117,6 +117,22 @@ describe('test/my-helper.test.js', () => {
     assert.deepEqual(execArgv, [ '--debug=5555', '--harmony', '--harmony_default_parameters' ]);
   });
 
+  it('helper.unparseExecArgv', () => {
+    const args = [
+      'echo',
+      '-r=111',
+      '-r=222',
+      '-r', '333',
+      '--require=444',
+      '--require', '555',
+    ];
+    const argv = yargs.parse(args);
+    argv._ = [];
+    argv.$0 = undefined;
+    const execArgv = helper.unparseExecArgv(argv);
+    assert.deepEqual(execArgv, [ '-r', '111', '-r', '222', '-r', '333', '-r', '444', '-r', '555' ]);
+  });
+
   it('helper.extractExecArgv', () => {
     const args = [
       'echo',


### PR DESCRIPTION
- 支持把 `--node_options` 的内容传递给 `execArgv`
- 提供新的 `unparseExecArgv` 方法，来处理 `node_options` 的 `--require` 问题
  -  node 的 execArgv 只能 `--inspect=666`，不能  `--inspect 666`
  -  node 的 execArgv 只能 `--require test.js`，不能  `--require=test.js`
  - 而原来的 `unparse` 函数只能全部有 `=` 或全没有
  - 因此特殊处理下。

close https://github.com/eggjs/egg/issues/1161