### PR TITLE
fix: execArgv convert rule

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 node-modules and other contributors
+Copyright (c) 2017-present node-modules and other contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/command.js
+++ b/lib/command.js
@@ -309,12 +309,28 @@ class CommonBin {
         argv[changeCase.camel(key)] = undefined;
       }
 
-      // only exports execArgv when any match
-      if (Object.keys(execArgvObj).length) {
-        context.execArgv = this.helper.unparseArgv(execArgvObj);
-        context.execArgvObj = execArgvObj;
-        context.debugOptions = debugOptions;
+      // exports execArgv
+      const self = this;
+      context.execArgvObj = execArgvObj;
+
+      // convert execArgvObj to execArgv
+      // `--require` should be `--require abc --require 123`, not allow `=`
+      // `--debug` should be `--debug=9999`, only allow `=`
+      Object.defineProperty(context, 'execArgv', {
+        get() {
+          const lazyExecArgvObj = context.execArgvObj;
+          const execArgv = self.helper.unparseArgv(lazyExecArgvObj, { excludes: [ 'require' ] });
+          if (lazyExecArgvObj.require) {
+            execArgv.push(...self.helper.unparseArgv({ require: lazyExecArgvObj.require }, { useEquals: false }));
+          }
+          return execArgv;
+        },
+      });
+
+      // only exports debugPort when any match
+      if (Object.keys(debugOptions).length) {
         context.debugPort = debugPort;
+        context.debugOptions = debugOptions;
       }
     }
 

--- a/test/fixtures/my-bin/command/parserRequire.js
+++ b/test/fixtures/my-bin/command/parserRequire.js
@@ -19,12 +19,12 @@ class ContextCommand extends Command {
   }
 
 
-  * run({ argv, execArgv, debugPort, debugOptions }) {
-    console.log('argv: %j', argv);
-    console.log('execArgv: %s', execArgv);
-    console.log('execArgv.length: %s', execArgv.length);
-    console.log('debugPort: %s', debugPort);
-    console.log('debugOptions: %j', debugOptions);
+  * run(context) {
+    context.execArgvObj = { require: 'abc' };
+    console.log('execArgv: %j', context.execArgv);
+
+    context.execArgvObj = { require: [ 'abc', '123' ] };
+    console.log('execArgv: %j', context.execArgv);
   }
 
   get description() {

--- a/test/my-bin.test.js
+++ b/test/my-bin.test.js
@@ -126,6 +126,19 @@ describe('test/my-bin.test.js', () => {
         .end(done);
     });
 
+    it('my-bin parserRequire', done => {
+      const args = [
+        'parserRequire',
+      ];
+      coffee.fork(myBin, args, { cwd })
+        // .debug()
+        // .coverage(false)
+        .expect('stdout', /execArgv: \["--require","abc"]/)
+        .expect('stdout', /execArgv: \["--require","abc","123"]/)
+        .expect('code', 0)
+        .end(done);
+    });
+
     it('my-bin parserDebug without execArgv', done => {
       const args = [
         'parserDebug',
@@ -136,7 +149,7 @@ describe('test/my-bin.test.js', () => {
         // .debug()
         // .coverage(false)
         .expect('stdout', /"debug-invalid":true,"debugInvalid":true/)
-        .expect('stdout', /execArgv: undefined/)
+        .expect('stdout', /execArgv.length: 0/)
         .expect('stdout', /debugPort: undefined/)
         .expect('stdout', /debugOptions: undefined/)
         .expect('code', 0)


### PR DESCRIPTION
Node 的 `execArgv` 比较变态：

- `--require xx.js --require bb.js` 不能有 `=`
- `--debug=9999` 必须有 `=`