### PR TITLE
deps: upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ sudo: false
 language: node_js
 node_js:
   - '6'
-  - '7'
   - '8'
+  - '10'
 install:
   - npm i npminstall && npminstall
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   matrix:
     - nodejs_version: '6'
-    - nodejs_version: '7'
     - nodejs_version: '8'
+    - nodejs_version: '10'
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/package.json
+++ b/package.json
@@ -4,25 +4,25 @@
   "description": "Abstraction bin tool",
   "main": "index.js",
   "dependencies": {
-    "chalk": "^2.1.0",
-    "change-case": "^3.0.1",
+    "chalk": "^2.4.1",
+    "change-case": "^3.0.2",
     "co": "^4.6.0",
-    "dargs": "^5.1.0",
-    "debug": "^3.0.1",
-    "is-type-of": "^1.2.0",
-    "semver": "^5.4.1",
-    "yargs": "^8.0.2",
-    "yargs-parser": "^7.0.0"
+    "dargs": "^6.0.0",
+    "debug": "^4.1.0",
+    "is-type-of": "^1.2.1",
+    "semver": "^5.5.1",
+    "yargs": "^12.0.2",
+    "yargs-parser": "^11.0.0"
   },
   "devDependencies": {
-    "autod": "^2.9.0",
-    "coffee": "^4.1.0",
-    "egg-bin": "^4.2.0",
+    "autod": "^3.0.1",
+    "coffee": "^5.1.0",
+    "egg-bin": "^4.9.0",
     "egg-ci": "^1.5.0",
-    "eslint": "^4.6.1",
-    "eslint-config-egg": "^5.1.1",
-    "mm": "^2.1.0",
-    "rimraf": "^2.6.1",
+    "eslint": "^5.6.1",
+    "eslint-config-egg": "^7.1.0",
+    "mm": "^2.4.1",
+    "rimraf": "^2.6.2",
     "webstorm-disable-index": "^1.1.2"
   },
   "repository": {
@@ -48,7 +48,7 @@
     "index.js"
   ],
   "ci": {
-    "version": "6, 7, 8",
+    "version": "6, 8, 10",
     "license": {
       "year": "2017",
       "fullname": "node-modules and other contributors"

--- a/test/fixtures/test-files/package.json
+++ b/test/fixtures/test-files/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-files",
   "dependencies": {
-    "egg-init-config": "^1.2.0"
+    "egg-init-config": "^1.5.0"
   }
 }


### PR DESCRIPTION
先 autod 下跑跑单测，回头 再看看 changelog

- 大部分是抛弃了 4.x 的支持
- `yargs@8 -> 12`，多了个 [Middleware](https://github.com/yargs/yargs/blob/master/docs/api.md#middlewarecallbacks)
- `yargs-parser@7 -> 11`
- `dargs@5 -> 6`
- `debug@3 -> 4` （吐槽下，CHANGELOG 都不更新了）
