### PR TITLE
 chore: add notice of WebStorm 2019

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -346,9 +346,6 @@ class CommonBin {
       if (Object.keys(debugOptions).length) {
         context.debugPort = debugPort;
         context.debugOptions = debugOptions;
-      } else if (process.debugPort) {
-        // WebStorm 2019 compatibility
-        context.debugOptions = debugOptions;
       }
     }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -297,6 +297,7 @@ class CommonBin {
       let { debugPort, debugOptions, execArgvObj } = this.helper.extractExecArgv(argv);
 
       // extract from WebStorm env `$NODE_DEBUG_OPTION`
+      // Notice: WebStorm 2019 won't export the env, instead, use `env.NODE_OPTIONS="--require="`, but we can't extract it.
       if (context.env.NODE_DEBUG_OPTION) {
         console.log('Use $NODE_DEBUG_OPTION: %s', context.env.NODE_DEBUG_OPTION);
         const argvFromEnv = parser(context.env.NODE_DEBUG_OPTION);
@@ -344,6 +345,9 @@ class CommonBin {
       // only exports debugPort when any match
       if (Object.keys(debugOptions).length) {
         context.debugPort = debugPort;
+        context.debugOptions = debugOptions;
+      } else if (process.debugPort) {
+        // WebStorm 2019 compatibility
         context.debugOptions = debugOptions;
       }
     }


### PR DESCRIPTION
WebStorm 2019 之前的检测方式失效了，加个注释